### PR TITLE
Fix GPU-params induced crash

### DIFF
--- a/conf/lstm_lm_conf.schema
+++ b/conf/lstm_lm_conf.schema
@@ -59,4 +59,4 @@ softmax = option('Softmax', 'NceLoss', 'SampledSoftmax', default=Softmax)
 
 [GPU]
 # All entries in this section (e.g. `per_process_gpu_memory_fraction`) are added to the TF `Session`'s `gpu_options`.
-per_process_gpu_memory_fraction = float(min=0, max=1, default=1)
+per_process_gpu_memory_fraction = float(min=0, max=1, default=None)

--- a/conf/lstm_lm_ptb_large.conf
+++ b/conf/lstm_lm_ptb_large.conf
@@ -19,4 +19,3 @@ max_grad_norm=10
 batch_size=20
 
 [GPU]
-per_process_gpu_memory_fraction=0.9

--- a/conf/lstm_lm_ptb_med.conf
+++ b/conf/lstm_lm_ptb_med.conf
@@ -19,4 +19,3 @@ max_grad_norm=5
 batch_size=20
 
 [GPU]
-per_process_gpu_memory_fraction=0.5

--- a/conf/lstm_lm_ptb_small.conf
+++ b/conf/lstm_lm_ptb_small.conf
@@ -19,4 +19,3 @@ max_grad_norm=5
 batch_size=20
 
 [GPU]
-per_process_gpu_memory_fraction=0.5

--- a/scripts/lstm_lm.py
+++ b/scripts/lstm_lm.py
@@ -35,6 +35,7 @@ def get_sconfig(gpu_params):
     Returns a session configuration object with the specified GPU parameters.
     """
     params = {}
+    gpu_params = {k: v for k, v in (gpu_params or {}).items() if v is not None}
     # params = {'log_device_placement': True}
     if gpu_params:
         params['gpu_options'] = tf.GPUOptions(**gpu_params)


### PR DESCRIPTION
GPU parameters' default is None. Such parameters are removed, and the
configuration will not contain a GPU section, if no parameters remain.

Fixes #23.